### PR TITLE
[ADD]dev user create

### DIFF
--- a/api/user/login.py
+++ b/api/user/login.py
@@ -8,9 +8,12 @@ from dotenv import load_dotenv
 from jose import jwt
 from datetime import datetime, timedelta
 
+
 KAKAO_REST_API_KEY = os.getenv("KAKAO_REST_API_KEY")
 secretkey = os.getenv("SECRET_KEY")
 algorithm = os.getenv("ALGORITHM")
+REDIRECT_URI = "http://localhost:8000/users/callback"
+
 
 def connect_kakao_server(authCode):
     url = "https://kauth.kakao.com/oauth/token"
@@ -40,7 +43,6 @@ def create_access_token(data : dict, expires_delta : timedelta or None = None):
 
 def get_token_data(authCode):
     res = connect_kakao_server(authCode)
-    
     user_data = res['access_token']
     token_type = res['token_type']
     url = 'https://kapi.kakao.com/v2/user/me'
@@ -76,3 +78,21 @@ def create_user(db : Session, user : user_schemas.UserCreate):
         token = create_access_token(data=user.__dict__)
         return token
     
+def get_dev_token_data(authCode):
+    # res = connect_kakao_server(authCode)
+    user_data = authCode
+    token_type = "Bearer"
+    url = 'https://kapi.kakao.com/v2/user/me'
+    header = {
+        "Authorization" : token_type + " " + user_data
+    }
+    response = requests.get(url = url, headers=header)
+    user_info = response.json()
+    data = {
+        "username" : user_info['kakao_account']['profile']['nickname'],
+        "email" : user_info['kakao_account']['email'],
+        "gender" : user_info['kakao_account']['gender'],
+        "age_range" : user_info['kakao_account']['age_range'],
+        "birthday" : user_info['kakao_account']['birthday']
+    }
+    return data

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from core.database import Base, engine
 import uvicorn
 
 app = FastAPI()
+app.router.redirect_slashes = False
 '''
 CORS
 '''

--- a/routers/users.py
+++ b/routers/users.py
@@ -1,9 +1,21 @@
+import requests,os
 from fastapi import APIRouter, Request, Response, HTTPException, Header, Depends,Cookie, status
-from api.user.login import create_user,get_token_data
+from api.user.login import create_user,get_token_data, get_dev_token_data
 from sqlalchemy.orm import Session
 from typing import Optional
 from core import database
 from schemas import user_schemas
+from fastapi.responses import RedirectResponse
+from urllib.parse import urlparse, parse_qs
+
+
+
+KAKAO_REST_API_KEY = os.getenv("KAKAO_REST_API_KEY")
+secretkey = os.getenv("SECRET_KEY")
+algorithm = os.getenv("ALGORITHM")
+REDIRECT_URI = "https://oauth.pstmn.io/v1/callback"
+auth_code = ''
+
 router = APIRouter(
     prefix="/users",
     tags=["users"],
@@ -12,6 +24,7 @@ router = APIRouter(
 @router.post("/login")
 async def LoginUser(
     response: Response,
+    request : Request,
     db : Session = Depends(database.get_db),
     authCode: Optional[str] = Header(None)
 ):
@@ -47,4 +60,37 @@ async def logout(
         return HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
              detail=str(e)
-        )  
+        )
+     
+@router.post('/dev')
+def dev_kakao_login(
+    response : Response,
+    db : Session = Depends(database.get_db),
+    authCode: Optional[str] = Header(None)
+):
+    user_create = get_dev_token_data(authCode=authCode)
+    user = user_schemas.UserCreate(
+            username = user_create["username"],
+            email = user_create["email"],
+            birthday = user_create["birthday"],
+            gender = user_create["gender"],
+            age_range = user_create["age_range"]
+        )
+    token = create_user(db = db, user = user)
+    print(token)
+    response.set_cookie(key = "access_token", value=token, secure=True, httponly=True)
+    return token
+        
+    return 
+
+
+@router.get('/callback')
+async def kakaoAuth(response: Response, code: Optional[str]="NONE",    db : Session = Depends(database.get_db),):
+    _url = f'https://kauth.kakao.com/oauth/token?grant_type=authorization_code&client_id={KAKAO_REST_API_KEY}&code={code}&redirect_uri={REDIRECT_URI}'
+    _res = requests.post(_url)
+    _result = _res.json()
+    # data = {"authCode" : _result['access_token']}
+    response.set_cookie(key="authCode", value=_result['access_token'])
+    # print(_result)
+    # print(_result['access_token'])
+    return 200


### PR DESCRIPTION
개발자 전용 유저 생성 API입니다. 
기존 카카오 로그인 로직을 반영하였으며 프론트엔드와의 연동사항때문에 제작하였습니다.
사용 방법은 postman Authorization 에서 로그인한이후 Header에 authCode : xxxx 라는 이름으로 등록한후 users/dev에 post요청시 유저테이블이 생성됩니다.
업무에 참고 바랍니다